### PR TITLE
Update styling

### DIFF
--- a/surabaya-client/src/App.module.css
+++ b/surabaya-client/src/App.module.css
@@ -15,7 +15,7 @@
   display: block;
   position: absolute;
   left: 300px;
-  overflow: auto;
+  overflow: hidden;
   top: 0px;
 }
 

--- a/surabaya-client/src/components/CodeDisplay/CodeDisplay.css
+++ b/surabaya-client/src/components/CodeDisplay/CodeDisplay.css
@@ -1,7 +1,17 @@
 .code-display {
   top: 0;
   right: 0;
-  width: 30vw !important;
   height: 100vh !important;
   position: absolute !important;
+}
+
+.CodeMirror {
+  top: 40px;
+  height: 700px;
+  width: 600px;
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+.CodeMirror-gutters {
+  background-color: rgba(255, 255, 255, 0.5);
 }

--- a/surabaya-client/src/components/CodeDisplay/index.tsx
+++ b/surabaya-client/src/components/CodeDisplay/index.tsx
@@ -1,22 +1,22 @@
 import React from "react";
 import "codemirror/lib/codemirror.css";
-import "codemirror/theme/xq-light.css";
+import "codemirror/theme/ttcn.css";
 import "codemirror/mode/clike/clike";
 import { Controlled as CodeMirror } from "react-codemirror2";
 import "./CodeDisplay.css";
-import { code } from "../../atoms";
+import { code as codeAtom } from "../../atoms";
 import { useRecoilValue } from "recoil";
 
 const CodeDisplay = () => {
-  const _code = useRecoilValue(code);
+  const code = useRecoilValue(codeAtom);
   return (
     <div className="code-display">
       <CodeMirror
         onBeforeChange={() => {}}
-        value={_code}
+        value={code}
         options={{
           mode: "text/x-java",
-          theme: "xq-light",
+          theme: "ttcn",
           lineNumbers: true,
         }}
       />


### PR DESCRIPTION
Made some fixes to styling:

- Made the code editor slightly transparent to match the legend
- Made the code editor bigger since it is toggle-able and with the current size it isn't good for reading large methods like `tokenize`
- Moved code editor to be permanently below the package name bar
- Removed horizontal scrollbar that appears when package name bar

![image](https://user-images.githubusercontent.com/61474884/84580933-df366000-ad90-11ea-94b3-421f02edcd05.png)
