### PR TITLE
Fix island placement

### DIFF
--- a/surabaya-client/package.json
+++ b/surabaya-client/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^7.1.2",
     "@types/d3-force": "^1.2.1",
     "@types/jest": "^25.2.3",
+    "@types/styled-components": "^5.1.0",
     "axios": "^0.19.2",
     "codemirror": "^5.54.0",
     "d3-force": "^2.0.1",

--- a/surabaya-client/public/index.html
+++ b/surabaya-client/public/index.html
@@ -5,16 +5,17 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
+    <meta name="description" content="Surabaya - a Java Project visualizer" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Oregano&display=swap"
+      rel="stylesheet"
+    />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -24,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Surabaya</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/surabaya-client/src/App.tsx
+++ b/surabaya-client/src/App.tsx
@@ -7,6 +7,7 @@ import RightSide from "./components/RightSide";
 import { JavaArchipelago } from "./lib/JavaArchipelago";
 import { Background } from "./components/Background";
 import { legendWidth } from "./util/constants";
+import WelcomeToSurabaya from "./components/WelcomeToSurabaya";
 
 const initialVisibility = {
   showDomesticDependencies: false,
@@ -38,12 +39,14 @@ function App() {
           />
           <ImportPanel setData={setData} />
         </div>
-        {data && (
+        {data ? (
           <RightSide
             javaProject={data}
             arrowVisibility={arrowVisibility}
             codeVisibility={codeVisibility}
           ></RightSide>
+        ) : (
+          <WelcomeToSurabaya />
         )}
       </div>
     </RecoilRoot>

--- a/surabaya-client/src/components/CodeDisplay/CodeDisplay.css
+++ b/surabaya-client/src/components/CodeDisplay/CodeDisplay.css
@@ -1,15 +1,23 @@
 .code-display {
-  top: 0;
-  right: 0;
+  top: 40px;
+  width: 30vw;
+  left: calc(70vw - 300px);
   height: 100vh !important;
   position: absolute !important;
+  display: flex;
 }
 
 .CodeMirror {
-  top: 40px;
-  height: 700px;
-  width: 600px;
+  position: absolute;
+  flex: 1;
+  right: 0;
+  width: 30vw;
+  height: 60vh;
   background-color: rgba(255, 255, 255, 0.7);
+}
+
+.CodeMirror-scroll {
+  margin: 0;
 }
 
 .CodeMirror-gutters {

--- a/surabaya-client/src/components/DependencyArrow/DomesticDependencyArrow.tsx
+++ b/surabaya-client/src/components/DependencyArrow/DomesticDependencyArrow.tsx
@@ -20,7 +20,7 @@ const DomesticDependencyArrow = ({ link, width, height }) => {
         className="importLine"
         d={`M${tX},${tY} Q${curveX || 0},${curveY || 0} ${sX},${sY}`}
       />
-      <image href={RightBoat} width="30px" x="-15px" y="-15px">
+      <image href={RightBoat} width="50px" x="-15px" y="-15px">
         <animateMotion
           dur="10s"
           repeatCount="indefinite"

--- a/surabaya-client/src/components/DependencyArrow/ForeignDependencyArrow.tsx
+++ b/surabaya-client/src/components/DependencyArrow/ForeignDependencyArrow.tsx
@@ -19,7 +19,7 @@ const ForeignDependencyArrow = ({ link, width, height }) => {
         className="foreignImportLine"
         d={`M${tX},${tY} Q${curveX || 0},${curveY || 0} ${sX},${sY}`}
       />
-      <image href={Airplane} width="40px" x="-20px" y="-20px">
+      <image href={Airplane} width="70px" x="-20px" y="-20px">
         <animateMotion
           dur="10s"
           repeatCount="indefinite"

--- a/surabaya-client/src/components/Island/index.tsx
+++ b/surabaya-client/src/components/Island/index.tsx
@@ -25,7 +25,7 @@ const IslandContainer = styled.div<{ minWidth }>`
   align-items: center;
 `;
 
-const IslandImage = styled.img<{ width; isHighlighted }>`
+const IslandImage = styled.img<{ width }>`
   width: ${(props) => `${props.width}px`};
   height: ${(props) => `${props.width}px`};
   position: absolute;

--- a/surabaya-client/src/components/PackageNameBanner/index.tsx
+++ b/surabaya-client/src/components/PackageNameBanner/index.tsx
@@ -2,16 +2,16 @@ import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
 
-const StyledPackageNameBanner = styled.div<{ width }>`
+const StyledPackageNameBanner = styled.div`
   position: absolute;
   top: 0px;
   left: 0px;
   height: 40px;
+  width: calc(100% - 300px);
   line-height: 40px;
   background-color: rgba(255, 255, 255, 0.5);
   border-right: 2px solid white;
   border-bottom: 2px solid white;
-  width: ${(props) => props.width}px;
   text-align: center;
   align-items: center;
   font-weight: bold;
@@ -23,7 +23,6 @@ const PackageText = styled.span<{ color: string }>`
 `;
 
 interface PackageNameBannerProps {
-  width: number;
   currentPackage?: string;
   packageColors?: any;
 }
@@ -31,13 +30,13 @@ interface PackageNameBannerProps {
 const PackageNameBanner: React.FC<PackageNameBannerProps> = (
   props: PackageNameBannerProps
 ) => {
-  const { width, currentPackage, packageColors } = props;
+  const { currentPackage, packageColors } = props;
   const textColor = packageColors?.[currentPackage];
 
   return (
     <>
       {currentPackage ? (
-        <StyledPackageNameBanner width={width}>
+        <StyledPackageNameBanner>
           Current package:{" "}
           <PackageText color={textColor}>{currentPackage}</PackageText>
         </StyledPackageNameBanner>

--- a/surabaya-client/src/components/WelcomeToSurabaya/index.tsx
+++ b/surabaya-client/src/components/WelcomeToSurabaya/index.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import styled from "styled-components";
+
+const Container = styled.div`
+  z-index: 100;
+  text-align: center;
+  display: flex;
+  width: 100%;
+  height: 100vh;
+  flex-direction: column;
+`;
+
+const Expand = styled.div`
+  flex: 1;
+`;
+
+const WelcomeTo = styled.p`
+  font-size: 2em;
+  font-family: "Oregano";
+  color: white;
+  animation: fadein 2s;
+
+  @keyframes fadein {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const Surabaya = styled.p`
+  font-size: 8em;
+  font-family: "Oregano";
+  color: white;
+  flex: 2;
+  animation: fadein 8s;
+
+  @keyframes fadein {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const Upload = styled.p`
+  font-size: 2em;
+  color: white;
+  font-family: "Oregano";
+  animation: fadein 8s;
+
+  @keyframes fadein {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+function WelcomeToSurabaya() {
+  return (
+    <Container>
+      <Expand />
+      <WelcomeTo>Welcome to</WelcomeTo>
+      <Surabaya>Surabaya 🏝️</Surabaya>
+      <Upload>⬅️ Upload a Java Project ☕ to visualize it</Upload>
+      <Expand />
+    </Container>
+  );
+}
+
+export default WelcomeToSurabaya;

--- a/surabaya-client/src/lib/JavaArchipelago.ts
+++ b/surabaya-client/src/lib/JavaArchipelago.ts
@@ -18,6 +18,7 @@ import {
   manyBodyStrength,
   simIterations,
   collisionRepulsionStrength,
+  clusterFactor,
 } from "../util/constants";
 import {
   getFullyQualifiedName,
@@ -192,14 +193,14 @@ export class JavaArchipelago {
       "foreignDependency",
       forceLink<JavaIsland, SimulationLinkDatum<JavaIsland>>(
         this.links.foreignDependencies
-      )
+      ).distance(clusterFactor)
     );
 
     sim.force(
       "foreignInheritance",
       forceLink<JavaIsland, SimulationLinkDatum<JavaIsland>>(
         this.links.foreignInheritances
-      )
+      ).distance(clusterFactor)
     );
 
     // Run simulations

--- a/surabaya-client/src/util/constants.js
+++ b/surabaya-client/src/util/constants.js
@@ -2,9 +2,11 @@ export const iconWidth = 25;
 export const marginSize = 7;
 export const legendWidth = 300; // used for absolute positioning of islands
 
-export const collisionRepulsionStrength = 3;
-export const manyBodyStrength = -1; // negative is repulsion
-export const simIterations = 200;
+export const collisionRepulsionStrength = 0.5; // larger favors separation of islands
+export const collisionRadiusFactor = 1; // larger favors separation of islands
+export const clusterFactor = 1300; // larger favors separation of packages
+export const manyBodyStrength = -0.1; // negative is repulsion, favors separation of islands
+export const simIterations = 400; // larger favors "more accurate" simulation
 
 export const fileNameSpace = 15;
 export const randomColorArray = [

--- a/surabaya-client/src/util/constants.js
+++ b/surabaya-client/src/util/constants.js
@@ -1,10 +1,11 @@
 export const iconWidth = 25;
 export const marginSize = 7;
 export const legendWidth = 300; // used for absolute positioning of islands
-export const domesticIslandDistance = 0;
-export const islandInterpackageDistance = 200;
-export const manyBodyStrength = -100; // negative is repulsion
-export const simIterations = 50;
+
+export const collisionRepulsionStrength = 3;
+export const manyBodyStrength = -1; // negative is repulsion
+export const simIterations = 200;
+
 export const fileNameSpace = 15;
 export const randomColorArray = [
   "blue",

--- a/surabaya-client/src/util/helpers.ts
+++ b/surabaya-client/src/util/helpers.ts
@@ -1,4 +1,9 @@
-import { marginSize, iconWidth, tooltipScale } from "./constants";
+import {
+  marginSize,
+  iconWidth,
+  tooltipScale,
+  collisionRadiusFactor,
+} from "./constants";
 import { JavaFile, JavaClass } from "../JavaProjectTypes";
 
 export function getNumColumnsForSquare(numberItems) {
@@ -70,5 +75,5 @@ export function getIslandWidth(javaFile: JavaFile): number {
 
 // For collision boundary
 export function getApproxRadiusFromWidth(width: number) {
-  return width * 1.3;
+  return width * collisionRadiusFactor;
 }


### PR DESCRIPTION
This is the result I got with these changes, the packages and islands are distributed pretty nicely, but have to zoom out to see the whole picture.



![image](https://user-images.githubusercontent.com/61474884/84583294-ddc66100-adab-11ea-81d7-ffd332e10b74.png)

![image](https://user-images.githubusercontent.com/61474884/84583303-05b5c480-adac-11ea-89ac-7500038d68e6.png)

(Also made a small fix to the package name banner and code editor for edge cases)

Made boats and planes slightly bigger now that different packages are farther apart
Also made a welcome screen:

![image](https://user-images.githubusercontent.com/61474884/84583826-208b3780-adb2-11ea-9521-c6c5752fde7a.png)

